### PR TITLE
Updating pip command to bring in smbus too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ You can optionally run `sudo raspi-config` or the graphical Raspberry Pi Configu
 
 # Installing
 
-Stable library from PyPi:
+Stable library from PyPi, the smbus library is also needed:
 
-* Just run `sudo pip install pimoroni-bme280`
+* Just run `sudo pip install pimoroni-bme280 smbus`
 
 Latest/development library from GitHub:
 


### PR DESCRIPTION
Had to do this on a fresh install of :

Raspbian Buster Lite
Version: February 2020
Release date: 2020-02-13
Kernel version: 4.19
SHA-256: 12ae6e17bf95b6ba83beca61e7394e7411b45eba7e6a520f434b0748ea7370e8

Tested on a raspberry pi zero-w

Hope it is useful :)
